### PR TITLE
Refactor Terraform code for VPC deployment

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -1,0 +1,36 @@
+# here, you define all the resources you are provisioning 
+
+data "aws_availability_zones" "available" {
+    state = "available"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block       = var.vpc_cidr_block
+  instance_tenancy = "default"
+
+  tags = {
+    Name = "${var.app_name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public_subnet" {
+  count = 2
+  vpc_id = aws_vpc.main.id
+  cidr_block = var.public_subnet_cidr_block[count.index]
+  availability_zone  = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.app_name}-public-subnet-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private_subnet" {
+  count = 2
+  vpc_id = aws_vpc.main.id
+  cidr_block = var.private_subnet_cidr_block[count.index]
+  availability_zone  = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.app_name}-private-subnet-${count.index + 1}"
+  }
+}

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "available_zones" {
+  value = data.aws_availability_zones.available.names
+}

--- a/vpc/providers.tf
+++ b/vpc/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  type        = string
+  description = "The region to deploy in"
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  description = "The CIDR block to use for the VPC"
+  default     = "10.0.0.0/24"
+}
+
+variable "public_subnet_cidr_block" {
+  type        = list(string)
+  description = "The CIDR block to use for the public subnet"
+  default     = ["10.0.0.0/26", "10.0.0.64/26"]
+}
+
+variable "private_subnet_cidr_block" {
+  type        = list(string)
+  description = "The CIDR block to use for the private subnet"
+  default     = ["10.0.0.128/26", "10.0.0.192/26"]
+}
+
+variable "app_name" {
+  type        = string
+  description = "The name of the application"
+  default     = "cwc"
+}


### PR DESCRIPTION
Modularized VPC resources into separate files
- Replaced hardcoded values with variables from `variables.tf`
- Utilized count to dynamically create resources
- Implemented data to fetch AWS availability zones

Files modified:
- `/vpc/main.tf:` Defined VPC, public and private subnets
- `/vpc/providers.tf`: Specified AWS provider region
- `/vpc/variables.tf`: Added variables for configuration